### PR TITLE
lazy cursor generation

### DIFF
--- a/src/ityped.js
+++ b/src/ityped.js
@@ -49,12 +49,21 @@
    */
   let selectedElement,
     props,
-    /**
-    * creating the cursor
-    */
-    cursor = document.createElement('span');
-  	cursor.classList.add('ityped-cursor');
-  	cursor.textContent = '|';
+    cursor;
+
+  /**
+   * @name generateCursor
+   * @description generates a cursor DOM node
+   * @return {HTMLSpanElement}
+  */
+  function generateCursor () {
+    if (!cursor) {
+      cursor = document.createElement('span');
+    	cursor.classList.add('ityped-cursor');
+    	cursor.textContent = '|';
+    }
+    return cursor.cloneNode();
+  }
 
   /**
    * @name setProps
@@ -97,7 +106,7 @@
   }
 
   function initCursorOn(element, cursorChar) {
-      const newCursor = cursor.cloneNode();
+      const newCursor = generateCursor();
 	  element.insertAdjacentElement('afterend', newCursor);
       newCursor.textContent = cursorChar;
   }


### PR DESCRIPTION
I know this is somewhat of a specific use case, but because my app runs on both Node and the client, any references to `document` blows up the app. Usually this is fine because you would just not initialize ityped on the server. However, here there was a reference to `document` that was breaking at initial code load.

This places cursor generation into a function so that it is only run on usage rather than at initial code load.